### PR TITLE
Add traverse functions

### DIFF
--- a/scalaz/main/scala/functions.scala
+++ b/scalaz/main/scala/functions.scala
@@ -2,5 +2,6 @@ package shapeless.contrib.scalaz
 
 trait Functions
   extends SequenceFunctions
+  with TraverseFunctions
 
 // vim: expandtab:ts=2:sw=2

--- a/scalaz/main/scala/traverse.scala
+++ b/scalaz/main/scala/traverse.scala
@@ -1,0 +1,31 @@
+package shapeless.contrib.scalaz
+
+import shapeless._
+import shapeless.Poly._
+import scalaz.Applicative
+
+trait TraverseFunctions {
+  sealed trait TraverserAux[I <: HList, O1 <: HList, O2 <: HList, F[_], P] {
+    def apply(in: I): F[O2]
+  }
+
+  sealed trait Traverser[I <: HList, O <: HList, F[_], P] {
+    def apply(in: I): F[O]
+  }
+
+  object Traverser {
+    implicit def fromTraverserAux[I <: HList, O <: HList, F[_], P](implicit traverserAux: TraverserAux[I, _,  O, F, P]): Traverser[I, O, F, P] = new Traverser[I, O, F, P] {
+      def apply(in: I) = traverserAux.apply(in)
+    }
+  }
+
+  object TraverserAux {
+    implicit def fromSequencerAndMapper[I <: HList, O1 <: HList, O2 <: HList, F[_], P](implicit mapper: MapperAux[P, I, O1], sequencer: Sequencer[F, O1, O2]): TraverserAux[I, O1, O2, F, P] = new TraverserAux[I, O1, O2, F, P] {
+      def apply(in: I) = sequencer(mapper(in))
+    }
+  }
+
+  def traverse[I <: HList, O <: HList, F[_]](in: I)(f: Poly)(implicit traverser: Traverser[I, O, F, f.type]): F[O] = traverser(in)
+}
+
+object TraverseFunctions extends TraverseFunctions

--- a/scalaz/test/scala/TraverseTest.scala
+++ b/scalaz/test/scala/TraverseTest.scala
@@ -1,0 +1,34 @@
+package shapeless.contrib.scalaz
+
+import org.specs2.scalaz.Spec
+
+import scalaz._
+import scalaz.scalacheck.ScalazArbitrary._
+
+import shapeless._
+
+class TraverseTest extends Spec {
+  import scalaz.std.option._
+  import scalaz.std.string._
+  import scalaz.syntax.apply._
+  import scalaz.syntax.validation._
+
+  def optToValidation[T](opt: Option[T]): Validation[String, T] = opt.map(_.success).getOrElse("Nothing there!".fail)
+
+  object headOption extends Poly1 {
+    implicit def caseSet[T] = at[Set[T]](_.headOption)
+  }
+
+  object optionToValidation extends Poly1 {
+    implicit def caseOption[T] = at[Option[T]](optToValidation)
+  }
+
+  "traversing Set with Set => Option" ! prop { (x: Set[Int], y: Set[String], z: Set[Float]) =>
+    traverse(x :: y :: z :: HNil)(headOption) must_== ((x.headOption |@| y.headOption |@| z.headOption) { _ :: _ :: _ :: HNil })
+  }
+
+  "traversing Option with Option => Validation" ! prop {(x: Option[Int], y: Option[String], z: Option[Float]) =>
+    traverse(x :: y :: z :: HNil)(optionToValidation) must_==
+      ((optToValidation(x) |@| optToValidation(y) |@| optToValidation(z)) { _ :: _ :: _ :: HNil })
+  }
+}


### PR DESCRIPTION
As of now, traverse is implemented by delegating through to sequence from shapeless.contrib.scalaz and Mapper from Shapeless core. Someone smarter than I am might choose to do the heavy lifting in traverse and have sequence call through to it with a polymorphic identity function.
