### PR TITLE
Clean up type parameters on Traverser and TraverserAux

### DIFF
--- a/scalaz/main/scala/traverse.scala
+++ b/scalaz/main/scala/traverse.scala
@@ -5,27 +5,29 @@ import shapeless.Poly._
 import scalaz.Applicative
 
 trait TraverseFunctions {
-  sealed trait TraverserAux[I <: HList, O1 <: HList, O2 <: HList, F[_], P] {
-    def apply(in: I): F[O2]
+  sealed trait TraverserAux[I <: HList, P, F[_], O <: HList] {
+    def apply(in: I): F[O]
   }
 
-  sealed trait Traverser[I <: HList, O <: HList, F[_], P] {
+  sealed trait Traverser[I <: HList, P, F[_]] {
+    type O <: HList
     def apply(in: I): F[O]
   }
 
   object Traverser {
-    implicit def fromTraverserAux[I <: HList, O <: HList, F[_], P](implicit traverserAux: TraverserAux[I, _,  O, F, P]): Traverser[I, O, F, P] = new Traverser[I, O, F, P] {
+    implicit def fromTraverserAux[I <: HList, P, F[_], O1 <: HList](implicit traverserAux: TraverserAux[I, P, F, O1]): Traverser[I, P, F] = new Traverser[I, P, F] {
+      type O = O1
       def apply(in: I) = traverserAux.apply(in)
     }
   }
 
   object TraverserAux {
-    implicit def fromSequencerAndMapper[I <: HList, O1 <: HList, O2 <: HList, F[_], P](implicit mapper: MapperAux[P, I, O1], sequencer: Sequencer[F, O1, O2]): TraverserAux[I, O1, O2, F, P] = new TraverserAux[I, O1, O2, F, P] {
+    implicit def fromSequencerAndMapper[I <: HList, P, F[_], S <: HList, O <: HList](implicit mapper: MapperAux[P, I, S], sequencer: Sequencer[F, S, O]): TraverserAux[I, P, F, O] = new TraverserAux[I, P, F, O] {
       def apply(in: I) = sequencer(mapper(in))
     }
   }
 
-  def traverse[I <: HList, O <: HList, F[_]](in: I)(f: Poly)(implicit traverser: Traverser[I, O, F, f.type]): F[O] = traverser(in)
+  def traverse[I <: HList, F[_], O <: HList](in: I)(f: Poly)(implicit traverser: Traverser[I, f.type, F]): F[traverser.O] = traverser(in)
 }
 
 object TraverseFunctions extends TraverseFunctions

--- a/scalaz/test/scala/TraverseTest.scala
+++ b/scalaz/test/scala/TraverseTest.scala
@@ -11,9 +11,9 @@ class TraverseTest extends Spec {
   import scalaz.std.option._
   import scalaz.std.string._
   import scalaz.syntax.apply._
-  import scalaz.syntax.validation._
+  import scalaz.syntax.std.option._
 
-  def optToValidation[T](opt: Option[T]): Validation[String, T] = opt.map(_.success).getOrElse("Nothing there!".fail)
+  def optToValidation[T](opt: Option[T]): Validation[String, T] = opt.toSuccess("Nothing there!")
 
   object headOption extends Poly1 {
     implicit def caseSet[T] = at[Set[T]](_.headOption)


### PR DESCRIPTION
I previously made these a bit more complicated than they need to be. I have now removed some unnecessary type parameters and changed the order of type parameters to prefer input types on the left and output types on the right.
