### PR TITLE
Add tests for sequencing HLists of Kleislis

### DIFF
--- a/scalaz/test/scala/SequenceTest.scala
+++ b/scalaz/test/scala/SequenceTest.scala
@@ -17,8 +17,18 @@ class SequenceTest extends Spec {
     sequence(x :: y :: z :: HNil) must_== ((x |@| y |@| z) { _ :: _ :: _ :: HNil })
   }
 
-  "sequencing Validation" ! prop { (x: Validation[String, Int], y: Validation[String, String], z: Validation[String, Float]) =>
+  "sequencing Validation" ! prop { (x: ValidationNel[String, Int], y: ValidationNel[String, String], z: ValidationNel[String, Float]) =>
     sequence(x :: y :: z :: HNil) must_== ((x |@| y |@| z) { _ :: _ :: _ :: HNil })
+  }
+
+  "sequencing Kleisli" ! prop { (x: Kleisli[Option, Int, String], y: Kleisli[Option, Int, Boolean], z: Kleisli[Option, Int, String], i: Int) =>
+    sequence(x :: y :: z :: HNil).apply(i) must_== (((x |@| y |@| z) { _ :: _ :: _ :: HNil }).apply(i))
+  }
+
+  type ErrorsOr[+A] = ValidationNel[String, A]
+
+  "sequencing Kleisli of ValidationNel" ! prop { (x: Kleisli[ErrorsOr, Int, String], y: Kleisli[ErrorsOr, Int, Boolean], z: Kleisli[ErrorsOr, Int, String], i: Int) =>
+    sequence(x :: y :: z :: HNil).apply(i) must_== (((x |@| y |@| z) { _ :: _ :: _ :: HNil }).apply(i))
   }
 
 }


### PR DESCRIPTION
The one for Kleislis of ValidationNels results in an implicit not found
error and is commented out.

@larsrh (or anyone else) do you know of a way to convince the compiler to pick up the sequencer for a Kleisli of a ValidationNel? (See commented out test)

EDIT: never mind. My type alias just needed to be covariant. I originally added these tests just to point out this issue, but even though there isn't an issue, I guess there's no harm in further test coverage.
