### PR TITLE
Update dependencies, particularly ScalaCheck for bin compatibility reasons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ import GitKeys._
 
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7")
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.10.6", "2.11.8")
 )
 
 addCommandAlias("root", ";project rootJVM")
@@ -27,11 +27,11 @@ addCommandAlias("validateJS", ";project rootJS;compile;test")
 
 addCommandAlias("releaseAll", ";root;release skip-tests")
 
-val shapelessVersion = "2.2.0"
-val scalacheckVersion = "1.12.5"
+val shapelessVersion = "2.3.2"
+val scalacheckVersion = "1.13.4"
 val scalazVersion = "7.2.0"
-val spireVersion = "0.11.0"
-val scalatestVersion = "3.0.0-M7"
+val spireVersion = "0.13.0"
+val scalatestVersion = "3.0.1"
 val specs2Version = "3.6.6-scalaz-7.2.0"
 val scalazSpecs2Version = "0.5.0-SNAPSHOT"
 
@@ -61,7 +61,6 @@ lazy val commonSettings = Seq(
 ) ++ scalaMacroDependencies
 
 lazy val commonJsSettings = Seq(
-  scalaJSUseRhino in Global := false,
   parallelExecution in Test := false
 )
 
@@ -178,13 +177,13 @@ lazy val publishSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { _ => false },
-  publishTo <<= version { (v: String) =>
+  publishTo := version { (v: String) =>
     val nexus = "https://oss.sonatype.org/"
     if (v.trim.endsWith("SNAPSHOT"))
       Some("snapshots" at nexus + "content/repositories/snapshots")
     else
       Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-  },
+  }.value,
   homepage := Some(url("http://typelevel.org/")),
   licenses := Seq("MIT" -> url("http://www.opensource.org/licenses/mit-license.php")),
   scmInfo :=

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.15"
 
 addSbtPlugin("com.typesafe"       % "sbt-mima-plugin"       % "0.1.8")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"               % "0.8.5")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"           % "0.6.7")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"           % "0.6.14")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"           % "1.0.0")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"               % "1.0.0")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"          % "1.1")


### PR DESCRIPTION
Motivation is that ScalaCheck 1.12.x is not binary compatible with ScalaCheck 1.13.x, so shapeless-scalacheck is not usable in a 1.13.x project. This required updating other dependencies, including spire.

Also update Scala, SBT, ScalaTest, Shapeless while I'm at it. Leaves scalaz and specs2 and most of the plugins at previous versions.