### PR TITLE
Change CrossVersion.full to use CrossVersion.patch for Typelevel Scala compatibility.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val spire = crossProject.crossType(CrossType.Pure)
   .settings(
     libraryDependencies ++= Seq(
       "com.chuusai"    %%% "shapeless"                % shapelessVersion,
-      "org.scala-lang" %   "scala-reflect"            % scalaVersion.value % "provided",
+      scalaOrganization.value % "scala-reflect"       % scalaVersion.value % "provided",
       "org.spire-math" %%% "spire"                    % spireVersion,
       "org.scalatest"  %%% "scalatest"                % scalatestVersion   % "test",
       "org.scalacheck" %%% "scalacheck"               % scalacheckVersion  % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,7 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
       case Some((2, 10)) =>
-        Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
+        Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch))
     }
   }
 )


### PR DESCRIPTION
Including text from the issue at [typelevel/scala#135](https://github.com/typelevel/scala/issues/135): 

> To use Typelevel Scala versions which are not exactly aligned with the corresponding Lightbend Scala version (ie. because they include an additional -bin-patch-nnn suffix in their version) we need to modify project builds which use CrossVersion.full (which includes the suffix) to use CrossVersion.patch (which doesn't) where appropriate (eg. for macro-paradise and other compiler plugins).